### PR TITLE
Template .env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,87 @@
+APP_NAME="Randall Wilk"
+APP_ENV={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/APP_ENV }}
+APP_KEY={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/APP_KEY }}
+APP_DEBUG={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/APP_DEBUG }}
+APP_URL={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/APP_URL }}
+APP_TIMEZONE=UTC
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+APP_FAKER_LOCALE=en_US
+
+APP_MAINTENANCE_DRIVER=file
+
+BCRYPT_ROUNDS=12
+
+LOG_CHANNEL=stack
+LOG_STACK=daily
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
+DB_CONNECTION=pgsql
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_DATABASE={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Database/DB_DATABASE }}
+DB_USERNAME={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Database/DB_USERNAME }}
+DB_PASSWORD={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Database/DB_PASSWORD }}
+
+SESSION_DRIVER=database
+SESSION_LIFETIME={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Session/SESSION_LIFETIME }}
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_COOKIE="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Session/SESSION_COOKIE }}"
+
+BROADCAST_CONNECTION={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/BROADCAST_CONNECTION }}
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/QUEUE_CONNECTION }}
+
+CACHE_STORE=redis
+
+MEMCACHED_HOST=127.0.0.1
+
+REDIS_CLIENT=phpredis
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+MAIL_MAILER={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Mail/MAIL_MAILER }}
+MAIL_HOST={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Mail/MAIL_HOST }}
+MAIL_PORT={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Mail/MAIL_PORT }}
+MAIL_USERNAME={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Mail/MAIL_USERNAME }}
+MAIL_PASSWORD={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Mail/MAIL_PASSWORD }}
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Mail/MAIL_FROM_ADDRESS }}
+MAIL_FROM_NAME="${APP_NAME}"
+
+# Google Analytics
+GOOGLE_ANALYTICS_ID={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Google/GOOGLE_ANALYTICS_ID }}
+
+# GitHub
+GITHUB_USERNAME={{ op://randallwilk.dev/randallwilk-env/GitHub/GITHUB_USERNAME }}
+GITHUB_TOKEN="{{ op://randallwilk.dev/randallwilk-env/GitHub/GITHUB_TOKEN }}"
+GITHUB_ACCESS_TOKEN={{ op://randallwilk.dev/randallwilk-env/GitHub/GITHUB_USERNAME }}
+GITHUB_WEBHOOK_SECRET="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/GitHub/GITHUB_WEBHOOK_SECRET }}"
+
+# GitHub Socialite
+GITHUB_CLIENT_ID="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/GitHub/GITHUB_CLIENT_ID }}"
+GITHUB_CLIENT_SECRET="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/GitHub/GITHUB_CLIENT_SECRET }}"
+GITHUB_CALLBACK_URL=/login/github/callback
+
+# Horizon
+HORIZON_EMAIL={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Horizon/HORIZON_EMAIL }}
+
+# Algolia
+ALGOLIA_APP_ID={{ op://randallwilk.dev/randallwilk-env/Algolia/ALGOLIA_APP_ID }}
+ALGOLIA_INDEX_NAME={{ op://randallwilk.dev/randallwilk-env/Algolia/ALGOLIA_INDEX_NAME }}
+ALGOLIA_API_KEY="{{ op://randallwilk.dev/randallwilk-env/Algolia/ALGOLIA_API_KEY }}"
+
+# Vite
+VITE_ALGOLIA_APP_ID="${ALGOLIA_APP_ID}"
+VITE_ALGOLIA_INDEX_NAME="${ALGOLIA_INDEX_NAME}"
+VITE_ALGOLIA_API_KEY="${ALGOLIA_API_KEY}"
+
+# Randall Wilk Config
+RANDALLWILK_TIMEZONE=America/Chicago
+RANDALLWILK_DEV_EMAIL={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Site/RANDALLWILK_DEV_EMAIL }}
+RANDALLWILK_DEV_NAME="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Site/RANDALLWILK_DEV_NAME }}"
+RANDALLWILK_SUPPORT_EMAIL="randall@randallwilk.dev"

--- a/.env.template
+++ b/.env.template
@@ -36,6 +36,7 @@ FILESYSTEM_DISK=local
 QUEUE_CONNECTION={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/QUEUE_CONNECTION }}
 
 CACHE_STORE=redis
+CACHE_PREFIX={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/CACHE_PREFIX }}
 
 MEMCACHED_HOST=127.0.0.1
 


### PR DESCRIPTION
Adding a new .env.template file to inject secrets from 1password during deployments in an effort to move away from committing encrypted versions of .env files to source control. Will also eliminate the need to decrypt env during deployments.