### PR TITLE
Hide sensitive columns on the user model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,10 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasName, 
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_recovery_codes',
+        'two_factor_enabled',
+        'github_id',
+        'is_admin',
     ];
 
     public static function humanKeyPrefix(): string


### PR DESCRIPTION
PR prevents sensitive user model columns from being serialized.