### PR TITLE
Add commands to keep staging in sync with production

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,10 +29,18 @@ DB_DATABASE={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Database/DB_DATABAS
 DB_USERNAME={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Database/DB_USERNAME }}
 DB_PASSWORD={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Database/DB_PASSWORD }}
 
+# Staging DB (for data sync)
+STAGING_DB_HOST={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Staging/STAGING_DB_HOST }}
+STAGING_DB_PORT={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Staging/STAGING_DB_PORT }}
+STAGING_DB_DATABASE={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Staging/STAGING_DB_DATABASE }}
+STAGING_DB_USERNAME={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Staging/STAGING_DB_USERNAME }}
+STAGING_DB_PASSWORD={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Staging/STAGING_DB_PASSWORD }}
+
 SESSION_DRIVER=database
 SESSION_LIFETIME={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Session/SESSION_LIFETIME }}
 SESSION_ENCRYPT=false
 SESSION_PATH=/
+SESSION_SECURE_COOKIE=true
 SESSION_COOKIE="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Session/SESSION_COOKIE }}"
 
 BROADCAST_CONNECTION={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/BROADCAST_CONNECTION }}
@@ -92,3 +100,4 @@ RANDALLWILK_TIMEZONE=America/Chicago
 RANDALLWILK_DEV_EMAIL={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Site/RANDALLWILK_DEV_EMAIL }}
 RANDALLWILK_DEV_NAME="{{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Site/RANDALLWILK_DEV_NAME }}"
 RANDALLWILK_SUPPORT_EMAIL="randall@randallwilk.dev"
+RANDALLWILK_STAGE_CLONE_IGNORE={{ op://randallwilk.dev/randallwilk.env-$APP_ENV/Staging/RANDALLWILK_STAGE_CLONE_IGNORE }}

--- a/app/Console/Commands/RedactSensitiveDataCommand.php
+++ b/app/Console/Commands/RedactSensitiveDataCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\Database\Redaction;
+use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+class RedactSensitiveDataCommand extends Command
+{
+    use Prohibitable;
+
+    /** @var array<int, class-string<\App\Support\Database\Redaction\Contracts\Redactor>> */
+    protected const array REDACTORS = [
+        Redaction\UserRedactor::class,
+    ];
+
+    protected $signature = 'app:redact-sensitive-data';
+
+    protected $description = 'Redact sensitive information in the database';
+
+    public function handle(): int
+    {
+        if ($this->isProhibited()) {
+            return SymfonyCommand::FAILURE;
+        }
+
+        $this->components->warn('Redacting sensitive data...');
+
+        foreach (static::REDACTORS as $redactor) {
+            $redactor = new $redactor;
+
+            $redactor->setOutput($this->output);
+            $redactor->setOutputComponents($this->components);
+
+            $redactor->handle();
+        }
+
+        $this->components->success('Sensitive data has been redacted.');
+
+        return SymfonyCommand::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RefreshStagingDataCommand.php
+++ b/app/Console/Commands/RefreshStagingDataCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\Database\DbDumper;
+use App\Support\Database\PostgreDumpImporter;
+use Illuminate\Console\Command;
+use Illuminate\Console\Prohibitable;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+use function Laravel\Prompts\confirm;
+
+class RefreshStagingDataCommand extends Command
+{
+    use Prohibitable;
+
+    protected $signature = 'app:refresh-staging-data
+                            {--only=* : Only clone the specified tables}
+                            {--exclude=* : Tables to exclude from cloning}
+    ';
+
+    protected $description = 'Clone production database to staging';
+
+    public function handle(): int
+    {
+        if (
+            $this->isProhibited() ||
+            (! $this->confirmToProceed())
+        ) {
+            return SymfonyCommand::FAILURE;
+        }
+
+        $this->cloneProductionToStaging();
+
+        $this->components->success(
+            'Staging database data has been refreshed. Remember to redact sensitive information in the staging environment and run migrations if necessary.'
+        );
+
+        return SymfonyCommand::SUCCESS;
+    }
+
+    protected function cloneProductionToStaging(): void
+    {
+        $this->components->info('Dumping production database...');
+
+        $dumper = DbDumper::make(compress: false)->resolve();
+        $file = __DIR__ . '/dump.sql';
+
+        $dumper->excludeTables(
+            collect($this->option('exclude'))
+                ->merge(config('randallwilk.staging.exclude_tables'))
+                ->all()
+        );
+
+        $dumper->doNotCreateTables();
+
+        $dumper->dumpToFile($file);
+
+        $this->truncateRelevantTables();
+
+        $this->importDumpIntoStaging($file);
+
+        File::delete($file);
+    }
+
+    protected function truncateRelevantTables(): void
+    {
+        $this->components->info('Truncating relevant staging tables...');
+
+        foreach ($this->tablesToClone() as $table) {
+            $this->stagingDb()->table($table)->truncate();
+        }
+    }
+
+    protected function importDumpIntoStaging(string $filename): void
+    {
+        $this->components->info('Importing production dump into staging database...');
+
+        PostgreDumpImporter::fromDumper(
+            DbDumper::make(connection: 'staging', compress: false),
+        )->import($filename);
+    }
+
+    protected function confirmToProceed(): bool
+    {
+        return confirm(
+            'This will overwrite data in your staging database. Are you sure you want to continue?',
+        );
+    }
+
+    protected function tablesToClone(): array
+    {
+        if ($only = $this->option('only')) {
+            return $only;
+        }
+
+        $allTables = Schema::connection(config('database.default'))->getTableListing();
+        $exclude = collect($this->option('exclude'))->merge(config('randallwilk.staging.exclude_tables'));
+
+        return collect($allTables)
+            ->filter(function (string $table) use ($exclude) {
+                if ($exclude->isNotEmpty()) {
+                    return ! $exclude->contains($table);
+                }
+
+                return true;
+            })
+            ->all();
+    }
+
+    protected function stagingDb(): Connection
+    {
+        return once(fn () => DB::connection('staging'));
+    }
+}

--- a/app/Exceptions/Database/DatabaseImportFailed.php
+++ b/app/Exceptions/Database/DatabaseImportFailed.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Database;
+
+use Exception;
+use Illuminate\Contracts\Process\ProcessResult;
+
+class DatabaseImportFailed extends Exception
+{
+    public static function processFailed(ProcessResult $result): static
+    {
+        return new static(
+            'The import process failed with a non successful exit code.' . static::formatProcessOutput($result),
+        );
+    }
+
+    protected static function formatProcessOutput(ProcessResult $result): string
+    {
+        $output = $result->output() ?: '<no output>';
+        $errorOutput = $result->errorOutput() ?: '<no output>';
+        $exitCodeText = $result->exitCode() ?: '<no exit text>';
+
+        return <<<CONSOLE
+
+            Command:
+            ========
+            {$result->command()}
+
+            Exit code:
+            ==========
+            {$exitCodeText}
+
+            Output:
+            =======
+            {$output}
+
+            Error output:
+            =============
+            {$errorOutput}
+        CONSOLE;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Console\Commands\RedactSensitiveDataCommand;
+use App\Console\Commands\RefreshStagingDataCommand;
 use App\Docs\DocumentationContentParser;
 use App\Docs\DocumentationPage;
 use App\Docs\DocumentationPathParser;
@@ -67,7 +69,11 @@ class AppServiceProvider extends ServiceProvider
 
     protected function configureCommands(): void
     {
-        DB::prohibitDestructiveCommands($this->app->isProduction());
+        $isProduction = $this->app->isProduction();
+
+        DB::prohibitDestructiveCommands($isProduction);
+        RedactSensitiveDataCommand::prohibit($isProduction);
+        RefreshStagingDataCommand::prohibit(! $isProduction);
     }
 
     protected function configureModels(): void

--- a/app/Support/Database/DbDumper.php
+++ b/app/Support/Database/DbDumper.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
+use Spatie\DbDumper\Compressors\GzipCompressor;
+use Spatie\DbDumper\Databases\PostgreSql;
+
+readonly class DbDumper
+{
+    public function __construct(
+        protected string $connection = 'pgsql',
+        protected bool $compress = true,
+    ) {
+    }
+
+    public static function make(string $connection = 'pgsql', bool $compress = true): static
+    {
+        return new static($connection, $compress);
+    }
+
+    public function resolve(): PostgreSql
+    {
+        $dbConfig = $this->config();
+
+        $host = Arr::get($dbConfig, 'read.host', Arr::get($dbConfig, 'host'));
+
+        $dumper = PostgreSql::create()
+            ->setHost($host)
+            ->setUserName($dbConfig['username'])
+            ->setPassword($dbConfig['password'])
+            ->setDbName($dbConfig['database'])
+            ->setDumpBinaryPath($dbConfig['dump_command_path'] ?? '')
+            ->setTimeout($dbConfig['dump_command_timeout'] ?? 0);
+
+        if ($this->compress) {
+            $dumper->useCompressor(new GzipCompressor);
+        }
+
+        if (isset($dbConfig['port'])) {
+            $dumper->setPort((int) $dbConfig['port']);
+        }
+
+        return $dumper;
+    }
+
+    public function config(): array
+    {
+        return once(fn () => DB::connection($this->connection)->getConfig());
+    }
+}

--- a/app/Support/Database/PostgreDumpImporter.php
+++ b/app/Support/Database/PostgreDumpImporter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database;
+
+use App\Exceptions\Database\DatabaseImportFailed;
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+use Spatie\DbDumper\Databases\PostgreSql;
+
+class PostgreDumpImporter
+{
+    protected PostgreSql $postgreSql;
+
+    public function __construct(protected DbDumper $dumper)
+    {
+        $this->postgreSql = $dumper->resolve();
+    }
+
+    public static function fromDumper(DbDumper $dumper): static
+    {
+        return new static($dumper);
+    }
+
+    public function import(string $file): void
+    {
+        $process = $this->getProcess($file);
+
+        $result = $process->run();
+
+        $this->checkIfImportWasSuccessful($result);
+    }
+
+    protected function getProcess(string $file): PendingProcess
+    {
+        $command = $this->getImportCommand($file);
+
+        fwrite($this->tmpFileHandle(), $this->postgreSql->getContentsOfCredentialsFile());
+        $temporaryCredentialsFile = stream_get_meta_data($this->tmpFileHandle())['uri'];
+
+        $envVars = (fn () => $this->getEnvironmentVariablesForDumpCommand($temporaryCredentialsFile))->call($this->postgreSql);
+
+        $timeout = (fn () => $this->timeout)->call($this->postgreSql);
+
+        return Process::timeout($timeout)
+            ->env($envVars)
+            ->command($command);
+    }
+
+    protected function getImportCommand(string $file): string
+    {
+        $quote = (fn () => $this->determineQuote())->call($this->postgreSql);
+        $config = $this->dumper->config();
+
+        $command = [
+            "{$quote}psql{$quote}",
+            '-U "' . data_get($config, 'username') . '"',
+            "-h {$this->postgreSql->getHost()}",
+            '-p ' . data_get($config, 'port'),
+            $this->postgreSql->getDbName(),
+        ];
+
+        return $this->echoToFile(implode(' ', $command), $file);
+    }
+
+    protected function echoToFile(string $command, string $dumpFile): string
+    {
+        $dumpFile = '"' . addcslashes($dumpFile, '\\"') . '"';
+
+        return $command . ' < ' . $dumpFile;
+    }
+
+    protected function tmpFileHandle(): mixed
+    {
+        return once(fn () => tmpfile());
+    }
+
+    protected function checkIfImportWasSuccessful(ProcessResult $result): void
+    {
+        throw_unless(
+            $result->successful(),
+            DatabaseImportFailed::processFailed($result),
+        );
+    }
+}

--- a/app/Support/Database/Redaction/BaseRedactor.php
+++ b/app/Support/Database/Redaction/BaseRedactor.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database\Redaction;
+
+use App\Support\Database\Redaction\Contracts\Redactor;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+abstract class BaseRedactor implements Redactor
+{
+    protected ?OutputStyle $output = null;
+
+    protected ?Factory $outputComponents = null;
+
+    abstract protected function query(): Builder;
+
+    abstract protected function redactRecord(Model $record): Model;
+
+    public function handle(): void
+    {
+        $model = $this->query()->getModel();
+
+        $this->outputComponents?->info("Redacting: {$model->getTable()}");
+
+        $model::withoutTimestamps(function () {
+            $bar = $this->output?->createProgressBar($this->query()->count());
+
+            $this
+                ->query()
+                ->chunkById($this->chunkSize(), function (Collection $chunk) use ($bar) {
+                    $records = $chunk
+                        ->map(fn (Model $record) => $this->redactRecord($record))
+                        ->mapWithKeys(fn (Model $record) => [$record->getKey() => $record->getDirty()])
+                        ->filter(fn (array $attributes) => filled($attributes));
+
+                    if ($records->isEmpty()) {
+                        return;
+                    }
+
+                    $this
+                        ->query()
+                        ->whereKey($records->keys())
+                        ->update($this->buildUpdateCases($records));
+
+                    $bar?->advance($chunk->count());
+                });
+
+            $bar?->finish();
+        });
+
+        $this->output?->newLine(2);
+    }
+
+    public function setOutput(OutputStyle $output): void
+    {
+        $this->output = $output;
+    }
+
+    public function setOutputComponents(Factory $outputComponents): void
+    {
+        $this->outputComponents = $outputComponents;
+    }
+
+    protected function buildUpdateCases(Collection $records): array
+    {
+        // Get all unique columns that need updating across all records.
+        $columns = $records
+            ->flatMap(fn (array $attributes) => array_keys($attributes))
+            ->unique()
+            ->values();
+
+        return $columns->mapWithKeys(function (string $column) use ($records) {
+            $cases = $records->map(function (array $attributes, int|string $id) use ($column) {
+                // Only include this record in the case if the column was modified.
+                if (! array_key_exists($column, $attributes)) {
+                    return null;
+                }
+
+                $value = $attributes[$column] === null
+                    ? 'NULL'
+                    : "'" . addslashes($attributes[$column]) . "'";
+
+                return "WHEN {$id} THEN {$value}";
+            })->filter()->values();
+
+            if ($cases->isEmpty()) {
+                return [];
+            }
+
+            return [
+                $column => DB::raw(
+                    'CASE id ' .
+                    $cases->implode(' ') .
+                    " ELSE {$column} END"
+                ),
+            ];
+        })->all();
+    }
+
+    protected function chunkSize(): int
+    {
+        return 500;
+    }
+
+    protected function maskEmail(?string $email): ?string
+    {
+        if (! $email) {
+            return null;
+        }
+
+        if (! Str::contains($email, '@')) {
+            return Str::mask($email, '*', 2);
+        }
+
+        [$handle, $domain] = explode('@', $email);
+
+        $start = strlen($handle) <= 3 ? 1 : 3;
+
+        return Str::mask($handle, '*', $start) . '@' . Str::mask($domain, '*', 3);
+    }
+
+    protected function maskValue(?string $value): ?string
+    {
+        if (! $value) {
+            return null;
+        }
+
+        $length = strlen($value);
+
+        if ($length === 1) {
+            return '*';
+        }
+
+        if ($length <= 3) {
+            return Str::mask($value, '*', 1);
+        }
+
+        $start = $length <= 5 ? 1 : 2;
+
+        return Str::mask($value, '*', $start, -1);
+    }
+}

--- a/app/Support/Database/Redaction/Contracts/Redactor.php
+++ b/app/Support/Database/Redaction/Contracts/Redactor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database\Redaction\Contracts;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+
+interface Redactor
+{
+    public function handle(): void;
+
+    public function setOutput(OutputStyle $output);
+
+    public function setOutputComponents(Factory $outputComponents);
+}

--- a/app/Support/Database/Redaction/UserRedactor.php
+++ b/app/Support/Database/Redaction/UserRedactor.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database\Redaction;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class UserRedactor extends BaseRedactor
+{
+    protected function query(): Builder
+    {
+        return User::query()->withoutGlobalScopes();
+    }
+
+    protected function redactRecord(Model $record): Model
+    {
+        return tap($record, function (User $user) {
+            $user->fill([
+                'two_factor_enabled' => false,
+                'two_factor_recovery_codes' => null,
+                'avatar_path' => null,
+                'remember_token' => null,
+            ]);
+
+            if ($this->isExemptFromRedaction($user)) {
+                return;
+            }
+
+            $user->fill([
+                'name' => trim($user->name->first . ' ' . ($this->maskValue($user->name->last) ?? '')),
+                'email' => $this->maskEmail($user->email),
+                'password' => Str::password(),
+                'github_id' => null,
+                'github_username' => null,
+            ]);
+        });
+    }
+
+    protected function isExemptFromRedaction(User $user): bool
+    {
+        return in_array($user->email, $this->usersToIgnore(), true);
+    }
+
+    private function usersToIgnore(): array
+    {
+        return once(fn () => config('randallwilk.staging.ignore_users') ?? []);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "rawilk/laravel-casters": "^3.0",
         "rawilk/laravel-settings": "^3.3",
         "rawilk/profile-filament-plugin": "^0.5",
+        "spatie/db-dumper": "^3.7",
         "spatie/fork": "^1.1",
         "spatie/laravel-login-link": "^1.1",
         "spatie/laravel-markdown": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "980cd16bd8f2ede57ec42c85863e805d",
+    "content-hash": "85cfa786ca1c662d266179c4f9ff33b2",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -7362,6 +7362,69 @@
                 }
             ],
             "time": "2024-07-31T10:46:19+00:00"
+        },
+        {
+            "name": "spatie/db-dumper",
+            "version": "3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "22553ab8c34a9bb70645cb9bc2d9f236f3135705"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/22553ab8c34a9bb70645cb9bc2d9f236f3135705",
+                "reference": "22553ab8c34a9bb70645cb9bc2d9f236f3135705",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "symfony/process": "^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.22"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/db-dumper/tree/3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-23T08:58:35+00:00"
         },
         {
             "name": "spatie/fork",

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'connections' => [
+        'staging' => [
+            'driver' => 'pgsql',
+            'url' => env('STAGING_DB_URL'),
+            'host' => env('STAGING_DB_HOST', '127.0.0.1'),
+            'port' => env('STAGING_DB_PORT', '5432'),
+            'database' => env('STAGING_DB_DATABASE', 'laravel'),
+            'username' => env('STAGING_DB_USERNAME', 'root'),
+            'password' => env('STAGING_DB_PASSWORD', ''),
+            'charset' => env('DB_CHARSET', 'utf8'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'search_path' => 'public',
+            'sslmode' => 'prefer',
+        ],
+    ],
+];

--- a/config/randallwilk.php
+++ b/config/randallwilk.php
@@ -202,4 +202,37 @@ return [
             ],
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Staging
+    |--------------------------------------------------------------------------
+    |
+    | Configuration that deals with the staging environment and cloning
+    | production data into staging.
+    |
+    */
+    'staging' => [
+        /**
+         * These tables should always be excluded from the production -> staging
+         * environment clone.
+         */
+        'exclude_tables' => [
+            'authenticator_apps',
+            'failed_jobs',
+            'job_batches',
+            'migrations',
+            'old_user_emails',
+            'password_reset_tokens',
+            'pending_user_emails',
+            'sessions',
+            'settings',
+            'webauthn_keys',
+        ],
+
+        /**
+         * These users should not be redacted when cloning from production -> staging.
+         */
+        'ignore_users' => explode(',', env('RANDALLWILK_STAGE_CLONE_IGNORE', '')),
+    ],
 ];

--- a/tests/Architecture/CommandsTest.php
+++ b/tests/Architecture/CommandsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Providers\AppServiceProvider;
 use Illuminate\Console\Command;
 
 arch()
@@ -10,4 +11,6 @@ arch()
     ->toHaveSuffix('Command')
     ->toHaveMethod('handle')
     ->toImplementNothing()
-    ->not->toBeUsed();
+    ->not->toBeUsed()->ignoring([
+        AppServiceProvider::class,
+    ]);

--- a/tests/Architecture/SupportTest.php
+++ b/tests/Architecture/SupportTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\Redaction\BaseRedactor;
+use App\Support\Database\Redaction\Contracts\Redactor;
+
+arch()
+    ->expect('App\Support\Database\Redaction')
+    ->toBeClasses()
+    ->ignoring('App\Support\Database\Redaction\Contracts');
+
+arch()
+    ->expect('App\Support\Database\Redaction\Contracts')
+    ->toBeInterfaces();
+
+arch()
+    ->expect('App\Support\Database\Redaction')
+    ->toExtend(BaseRedactor::class)
+    ->ignoring([
+        'App\Support\Database\Redaction\Contracts',
+    ])
+    ->toImplement(Redactor::class);
+
+arch()
+    ->expect('App\Support\Database\Redaction')
+    ->classes()
+    ->toHaveSuffix('Redactor');


### PR DESCRIPTION
This PR helps automate the process of keeping the staging database in sync with the production database, as well as helping automate redacting sensitive columns in non-production environments.

First command is `app:refresh-staging-data`, which is used to clone production data into the staging database. It can only be run in production, and always excludes certain tables that shouldn't be cloned, such as sessions.

Second command is `app:redact-sensitive-data`, which can be called to redact sensitive information in the database, such as email addresses. This command cannot be run in a production environment. There's also a new config value (`randallwilk.staging.ignore_users`), which is useful for not redacting email addresses for certain users, so I don't have to mess around with having a redacted email address for the admin user to sign into non-production environments.